### PR TITLE
Support custom reporters

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,31 +2,82 @@
 
 ## Usage
 
-Apply the jshint loader as preloader.
+Apply the jshint loader as pre/postLoader in your webpack configuration:
 
 ``` javascript
-preLoaders: [
-	{
-		test: /\.js$/, // include .js files
-		exclude: /node_modules/, // exclude any and all files in the node_modules folder
-		loader: "jshint"
-	}
-],
-// more options in the optional jshint object
-jshint: {
-	// any jshint option http://www.jshint.com/docs/
-	// i. e.
-	camelcase: true,
+module.exports = {
+	module: {
+		preLoaders: [
+			{
+				test: /\.js$/, // include .js files
+				exclude: /node_modules/, // exclude any and all files in the node_modules folder
+				loader: "jshint-loader"
+			}
+		]
+	},
 
-	// jshint errors are displayed by default as warnings
-	// set emitErrors to true to display they as errors
-	emitErrors: false,
-	
-	// jshint to not interrupt the compilation
-	// if you want any file with jshint errors to fail
-	// set failOnHint to true
-	failOnHint: false
+	// more options in the optional jshint object
+	jshint: {
+		// any jshint option http://www.jshint.com/docs/
+		// i. e.
+		camelcase: true,
+
+		// jshint errors are displayed by default as warnings
+		// set emitErrors to true to display them as errors
+		emitErrors: false,
+
+		// jshint to not interrupt the compilation
+		// if you want any file with jshint errors to fail
+		// set failOnHint to true
+		failOnHint: false
+
+		// custom reporter function
+		reporter: function(errors) { }
+	}
 }
+```
+
+### Custom reporter
+
+By default, `jshint-loader` will provide a default reporter.
+
+However, if you prefer a custom reporter, pass a function under the `reporter` key in `jshint` options. (see *usage* above)
+
+The reporter function will be passed an array of errors/warnings produced by jshint
+with the following structure:
+```js
+[
+{
+    id:        [string, usually '(error)'],
+    code:      [string, error/warning code],
+    reason:    [string, error/warning message],
+    evidence:  [string, a piece of code that generated this error]
+    line:      [number]
+    character: [number]
+    scope:     [string, message scope;
+                usually '(main)' unless the code was eval'ed]
+
+    [+ a few other legacy fields that you don't need to worry about.]
+},
+// ...
+// more errors/warnings
+]
+```
+
+The reporter function will be excuted with the loader context as `this`. You may emit messages using `this.emitWarning(...)` or `this.emitError(...)`. See [webpack docs on loader context](http://webpack.github.io/docs/loaders.html#loader-context).
+
+**Note:** jshint reporters are **not compatible** with jshint-loader!
+This is due to the fact that reporter input is only processed from one file; not multiple files. Error reporting in this manner differs from [tranditional reporters](http://www.jshint.com/docs/reporters/) for jshint
+since the loader plugin (i.e. jshint-loader) is executed for each source file; and thus the reporter is executed for each file.
+
+The output in webpack CLI will usually be:
+```js
+...
+
+WARNING in ./path/to/file.js
+<reporter output>
+
+...
 ```
 
 ## License

--- a/index.js
+++ b/index.js
@@ -42,6 +42,10 @@ module.exports = function(input) {
 	var failOnHint = options.failOnHint;
 	delete options.failOnHint;
 
+	// custom reporter
+	var reporter = options.reporter;
+	delete options.reporter;
+
 	// module system globals
 	globals.require = true;
 	globals.module = true;
@@ -54,18 +58,22 @@ module.exports = function(input) {
 	var result = jshint(source, options, globals);
 	var errors = jshint.errors;
 	if(!result) {
-		var hints = [];
-		if(errors) errors.forEach(function(error) {
-			if(!error) return;
-			var message = "  " + error.reason + " @ line " + error.line + " char " + error.character + "\n    " + error.evidence;
-			hints.push(message);
-		}, this);
-		var message = hints.join("\n\n");
-		var emitter = emitErrors ? this.emitError : this.emitWarning;
-		if(emitter)
-			emitter("jshint results in errors\n" + message);
-		else
-			throw new Error("Your module system doesn't support emitWarning. Update availible? \n" + message);
+		if(reporter) {
+			reporter.call(this, errors);
+		} else {
+			var hints = [];
+			if(errors) errors.forEach(function(error) {
+				if(!error) return;
+				var message = "  " + error.reason + " @ line " + error.line + " char " + error.character + "\n    " + error.evidence;
+				hints.push(message);
+			}, this);
+			var message = hints.join("\n\n");
+			var emitter = emitErrors ? this.emitError : this.emitWarning;
+			if(emitter)
+				emitter("jshint results in errors\n" + message);
+			else
+				throw new Error("Your module system doesn't support emitWarning. Update availible? \n" + message);
+		}
 	}
 	if(failOnHint && !result)
 		throw new Error("Module failed in cause of jshint error.");


### PR DESCRIPTION
Wondering about this after looking at 
- https://github.com/sindresorhus/jshint-stylish
- http://www.jshint.com/docs/reporters/

As far as I can tell, `reporter` isn't defined via jshint options in node.js (wouldn't really make sense).

Input to a custom report would be similar to input to jshint reporters except like this:

``` js
[
{
    id:        [string, usually '(error)'],
    code:      [string, error/warning code],
    reason:    [string, error/warning message],
    evidence:  [string, a piece of code that generated this error]
    line:      [number]
    character: [number]
    scope:     [string, message scope;
                usually '(main)' unless the code was eval'ed]

    [+ a few other legacy fields that you don't need to worry about.]
},
//...
]
```

The array structure differ since all errors/warnings/info are associated to _only one_ file, for every file the js-loader processes. Thus, traditional jshint reporters aren't compatible.
- If there is no custom defined reporter, the default one will be provided.
- Custom reporters are executed with the loader's context as `this`. This provides emit functions.

---

Would this be a good idea? Let me know otherwise.

At the moment, I'm using this in my project.
