### PR TITLE
docs(readme): updates for JSF maintainers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,25 @@
-# jshint loader for webpack
+[![npm][npm]][npm-url]
+[![deps][deps]][deps-url]
+[![test][test]][test-url]
+[![chat][chat]][chat-url]
 
-## Usage
+<div align="center">
+  <!-- replace with accurate logo e.g from https://worldvectorlogo.com/ -->
+  <a href="https://github.com/webpack/webpack">
+    <img width="200" height="200" vspace="" hspace="25"
+      src="https://cdn.rawgit.com/webpack/media/e7485eb2/logo/icon.svg">
+  </a>
+  <h1>jshint Loader</h1>
+  <p>jshint loader for Webpack.<p>
+</div>
+
+<h2 align="center">Install</h2>
+
+```bash
+npm i jshint-loader --save
+```
+
+<h2 align="center">Usage</h2>
 
 Apply the jshint loader as pre/postLoader in your webpack configuration:
 
@@ -37,7 +56,7 @@ module.exports = {
 }
 ```
 
-### Custom reporter
+<h2 align="center">Custom reporter</h2>
 
 By default, `jshint-loader` will provide a default reporter.
 
@@ -79,7 +98,50 @@ WARNING in ./path/to/file.js
 
 ...
 ```
+`
 
-## License
+<h2 align="center">Maintainers</h2>
 
-MIT (http://www.opensource.org/licenses/mit-license.php)
+<table>
+  <tbody>
+    <tr>
+      <td align="center">
+        <img width="150" height="150"
+        src="https://avatars3.githubusercontent.com/u/166921?v=3&s=150">
+        </br>
+        <a href="https://github.com/bebraw">Juho Vepsäläinen</a>
+      </td>
+      <td align="center">
+        <img width="150" height="150"
+        src="https://avatars2.githubusercontent.com/u/8420490?v=3&s=150">
+        </br>
+        <a href="https://github.com/d3viant0ne">Joshua Wiens</a>
+      </td>
+      <td align="center">
+        <img width="150" height="150"
+        src="https://avatars3.githubusercontent.com/u/533616?v=3&s=150">
+        </br>
+        <a href="https://github.com/SpaceK33z">Kees Kluskens</a>
+      </td>
+      <td align="center">
+        <img width="150" height="150"
+        src="https://avatars3.githubusercontent.com/u/3408176?v=3&s=150">
+        </br>
+        <a href="https://github.com/TheLarkInn">Sean Larkin</a>
+      </td>
+    </tr>
+  <tbody>
+</table>
+
+
+[npm]: https://img.shields.io/npm/v/jshint-loader.svg
+[npm-url]: https://npmjs.com/package/jshint-loader
+
+[deps]: https://david-dm.org/webpack-contrib/jshint-loader.svg
+[deps-url]: https://david-dm.org/webpack-contrib/jshint-loader
+
+[chat]: https://img.shields.io/badge/gitter-webpack%2Fwebpack-brightgreen.svg
+[chat-url]: https://gitter.im/webpack/webpack
+
+[test]: http://img.shields.io/travis/webpack-contrib/jshint-loader.svg
+[test-url]: https://travis-ci.org/webpack-contrib/jshint-loader


### PR DESCRIPTION
As part of the effort to reach compliance with JSF and get the CLA bot enabled, maintainers need to be clearly displayed.

While I was at it, I did the updates to the readme using the template chosen for the standards effort.