### PR TITLE
Find and coalesce .jshintrc files

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,5 +1,5 @@
 {
-    "bitwise": true,
+    "bitwise": false,
     "expr": true,
     "shadow": true,
     "mocha": true,

--- a/index.js
+++ b/index.js
@@ -6,57 +6,8 @@
 "use strict";
 
 var jshint = require("jshint").JSHINT;
-var RcLoader = require("rcloader");
-var stripJsonComments = require("strip-json-comments");
 var loaderUtils = require("loader-utils");
-var fs = require("fs");
-
-
-// setup RcLoader
-var rcLoader = new RcLoader(".jshintrc", null, {
-	loader: function(path) {
-		return path;
-	}
-});
-
-function loadRcConfig(callback){
-	var sync = typeof callback !== "function";
-
-	if(sync){
-		var path = rcLoader.for(this.resourcePath);
-		if(typeof path !== "string") {
-			// no .jshintrc found
-			return {};
-		} else {
-			this.addDependency(path);
-			var file = fs.readFileSync(path, "utf8");
-			return JSON.parse(stripJsonComments(file));
-		}
-	}
-	else {
-		rcLoader.for(this.resourcePath, function(err, path) {
-			if(typeof path !== "string") {
-				// no .jshintrc found
-				return callback(null, {});
-			}
-
-			this.addDependency(path);
-			fs.readFile(path, "utf8", function(err, file) {
-				var options;
-
-				if(!err) {
-					try {
-						options = JSON.parse(stripJsonComments(file));
-					}
-					catch(e) {
-						err = new Error("Can't parse config file: " + path);
-					}
-				}
-				callback(err, options);
-			});
-		}.bind(this));
-	}
-}
+var loadRcConfig = require("./lib/loadRcConfig");
 
 function jsHint(input, options) {
 	// copy options to own object

--- a/lib/loadRcConfig.js
+++ b/lib/loadRcConfig.js
@@ -1,0 +1,73 @@
+var RcLoader = require("rcloader");
+var stripJsonComments = require("strip-json-comments");
+var path = require("path");
+var shjs = require("shelljs");
+var _ = require("lodash");
+
+// setup RcLoader
+var rcLoader = new RcLoader(".jshintrc", null, {
+  loader: function(path) {
+    return path;
+  }
+});
+
+function loadRcConfig(callback){
+  var sync = typeof callback !== "function";
+
+  if(sync){
+    var fp = rcLoader.for(this.resourcePath);
+    if(typeof fp !== "string") {
+      // no .jshintrc found
+      return {};
+    } else {
+      this.addDependency(fp);
+      var options = loadConfig(fp);
+      delete options.dirname;
+      return options;
+    }
+  }
+  else {
+    rcLoader.for(this.resourcePath, function(err, fp) {
+      if(typeof fp !== "string") {
+        // no .jshintrc found
+        return callback(null, {});
+      }
+
+      this.addDependency(fp);
+      var options = loadConfig(fp);
+      delete options.dirname;
+      callback(err, options);
+    }.bind(this));
+  }
+}
+
+function loadConfig(fp) {
+  if (!fp) {
+    return {};
+  }
+
+  if (!shjs.test("-e", fp)) {
+    throw new Error("Can't find config file: " + fp);
+  }
+
+  try {
+    var config = JSON.parse(stripJsonComments(shjs.cat(fp)));
+    config.dirname = path.dirname(fp);
+
+    if (config["extends"]) {
+      var baseConfig = loadConfig(path.resolve(config.dirname, config["extends"]));
+      config = _.merge({}, baseConfig, config, function(a, b) {
+        if (_.isArray(a)) {
+          return a.concat(b);
+        }
+      });
+      delete config["extends"];
+    }
+
+    return config;
+  } catch (err) {
+    throw new Error("Can't parse config file: " + fp + "\nError:" + err);
+  }
+}
+
+module.exports = loadRcConfig;

--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
   "description": "jshint loader module for webpack",
   "dependencies": {
     "loader-utils": "0.2.x",
+    "lodash": "4.17.4",
     "rcloader": "=0.1.2",
+    "shelljs": "0.7.6",
     "strip-json-comments": "0.1.x"
   },
   "peerDependencies": {

--- a/test/.jshintrc
+++ b/test/.jshintrc
@@ -1,0 +1,4 @@
+{
+  "extends": "../.jshintrc",
+  "bitwise": true
+}

--- a/test/index.js
+++ b/test/index.js
@@ -1,10 +1,10 @@
 "use strict";
 
 var should = require("should");
-var loader = require("./index");
 var config = require("./webpack.config");
 var webpack = require("webpack");
-var sinon = require('sinon');
+var sinon = require("sinon");
+var loadRcConfig = require("../lib/loadRcConfig");
 
 describe("jshint loader", function() {
 
@@ -13,6 +13,20 @@ describe("jshint loader", function() {
 	beforeEach(function() {
 		conf = Object.assign({}, config, {
 			entry: "./test/mocks/default.js"
+		});
+	});
+
+	it("should find and coalesce nested .jshintrc files", function() {
+		var host = {
+			resourcePath: conf.entry,
+			addDependency: function() {}
+		};
+		loadRcConfig.call(host).should.deepEqual({
+			bitwise: true,
+			expr: true,
+			shadow: true,
+			mocha: true,
+			node: true
 		});
 	});
 
@@ -102,4 +116,5 @@ describe("jshint loader", function() {
 			});
 		});
 	});
+
 });


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe: 


**What is the current behavior?** (You can also link to an open issue here)
jshint-loader uses the first .jshintrc file it finds and ignores the `extends` property.


**What is the new behavior?**
Brings jshint-loader to parity with jshint cli with respect to its ability to find and coalesce nested .jshintrc files.


**Does this PR introduce a breaking change?**
- [ ] Yes
- [ ] No 
I don't know whether this is a breaking change. Seems ok to me.
