### PR TITLE
Find and coalesce .jshintrc files

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,57 +6,8 @@
 "use strict";
 
 var jshint = require("jshint").JSHINT;
-var RcLoader = require("rcloader");
-var stripJsonComments = require("strip-json-comments");
 var loaderUtils = require("loader-utils");
-var fs = require("fs");
-
-
-// setup RcLoader
-var rcLoader = new RcLoader(".jshintrc", null, {
-	loader: function(path) {
-		return path;
-	}
-});
-
-function loadRcConfig(callback){
-	var sync = typeof callback !== "function";
-
-	if(sync){
-		var path = rcLoader.for(this.resourcePath);
-		if(typeof path !== "string") {
-			// no .jshintrc found
-			return {};
-		} else {
-			this.addDependency(path);
-			var file = fs.readFileSync(path, "utf8");
-			return JSON.parse(stripJsonComments(file));
-		}
-	}
-	else {
-		rcLoader.for(this.resourcePath, function(err, path) {
-			if(typeof path !== "string") {
-				// no .jshintrc found
-				return callback(null, {});
-			}
-
-			this.addDependency(path);
-			fs.readFile(path, "utf8", function(err, file) {
-				var options;
-
-				if(!err) {
-					try {
-						options = JSON.parse(stripJsonComments(file));
-					}
-					catch(e) {
-						err = new Error("Can't parse config file: " + path);
-					}
-				}
-				callback(err, options);
-			});
-		}.bind(this));
-	}
-}
+var loadRcConfig = require("./lib/loadRcConfig");
 
 function jsHint(input, options) {
 	// copy options to own object

--- a/lib/loadRcConfig.js
+++ b/lib/loadRcConfig.js
@@ -1,0 +1,73 @@
+var RcLoader = require("rcloader");
+var stripJsonComments = require("strip-json-comments");
+var path = require("path");
+var shjs = require("shelljs");
+var _ = require("lodash");
+
+// setup RcLoader
+var rcLoader = new RcLoader(".jshintrc", null, {
+  loader: function(path) {
+    return path;
+  }
+});
+
+function loadRcConfig(callback){
+  var sync = typeof callback !== "function";
+
+  if(sync){
+    var fp = rcLoader.for(this.resourcePath);
+    if(typeof fp !== "string") {
+      // no .jshintrc found
+      return {};
+    } else {
+      this.addDependency(fp);
+      var options = loadConfig(fp);
+      delete options.dirname;
+      return options;
+    }
+  }
+  else {
+    rcLoader.for(this.resourcePath, function(err, fp) {
+      if(typeof fp !== "string") {
+        // no .jshintrc found
+        return callback(null, {});
+      }
+
+      this.addDependency(fp);
+      var options = loadConfig(fp);
+      delete options.dirname;
+      callback(err, options);
+    }.bind(this));
+  }
+}
+
+function loadConfig(fp) {
+  if (!fp) {
+    return {};
+  }
+
+  if (!shjs.test("-e", fp)) {
+    throw new Error("Can't find config file: " + fp);
+  }
+
+  try {
+    var config = JSON.parse(stripJsonComments(shjs.cat(fp)));
+    config.dirname = path.dirname(fp);
+
+    if (config["extends"]) {
+      var baseConfig = loadConfig(path.resolve(config.dirname, config["extends"]));
+      config = _.merge({}, baseConfig, config, function(a, b) {
+        if (_.isArray(a)) {
+          return a.concat(b);
+        }
+      });
+      delete config["extends"];
+    }
+
+    return config;
+  } catch (err) {
+    throw new Error("Can't parse config file: " + fp + "\nError:" + err);
+  }
+}
+
+module.exports = loadRcConfig;

--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
   "description": "jshint loader module for webpack",
   "dependencies": {
     "loader-utils": "^1.0.2",
+    "lodash": "4.17.4",
     "rcloader": "=0.1.2",
+    "shelljs": "0.7.6",
     "strip-json-comments": "0.1.x"
   },
   "peerDependencies": {

--- a/test/.jshintrc
+++ b/test/.jshintrc
@@ -1,0 +1,4 @@
+{
+  "extends": "../.jshintrc",
+  "quotmark": true
+}

--- a/test/index.js
+++ b/test/index.js
@@ -1,10 +1,10 @@
 "use strict";
 
 var should = require("should");
-var loader = require("./index");
 var config = require("./webpack.config");
 var webpack = require("webpack");
-var sinon = require('sinon');
+var sinon = require("sinon");
+var loadRcConfig = require("../lib/loadRcConfig");
 
 describe("jshint loader", function() {
 
@@ -13,6 +13,21 @@ describe("jshint loader", function() {
 	beforeEach(function() {
 		conf = Object.assign({}, config, {
 			entry: "./test/mocks/default.js"
+		});
+	});
+
+	it("should find and coalesce nested .jshintrc files", function() {
+		var host = {
+			resourcePath: conf.entry,
+			addDependency: function() {}
+		};
+		loadRcConfig.call(host).should.deepEqual({
+			bitwise: true,
+			expr: true,
+			shadow: true,
+			mocha: true,
+			node: true,
+			quotmark: "double"
 		});
 	});
 
@@ -102,4 +117,5 @@ describe("jshint loader", function() {
 			});
 		});
 	});
+
 });

--- a/test/mocks/.jshintrc
+++ b/test/mocks/.jshintrc
@@ -1,0 +1,4 @@
+{
+  "extends": "../.jshintrc",
+  "quotmark": "double"
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -566,7 +566,7 @@ glob@7.0.5:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@^7.0.5, glob@^7.1.1:
+glob@^7.0.0, glob@^7.0.5, glob@^7.1.1:
   version "7.1.1"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.1.tgz#805211df04faaf1c63a3600306cdf5ade50b2ec8"
   dependencies:
@@ -677,6 +677,10 @@ ini@~1.3.0:
 interpret@^0.6.4:
   version "0.6.6"
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-0.6.6.tgz#fecd7a18e7ce5ca6abfb953e1f86213a49f1625b"
+
+interpret@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.0.1.tgz#d579fb7f693b858004947af39fa0db49f795602c"
 
 is-binary-path@^1.0.0:
   version "1.0.1"
@@ -900,6 +904,10 @@ lodash@3.7.x:
   version "3.7.0"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-3.7.0.tgz#3678bd8ab995057c07ade836ed2ef087da811d45"
 
+lodash@4.17.4:
+  version "4.17.4"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
+
 lodash@~2.4.1:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-2.4.2.tgz#fadd834b9683073da179b3eae6d9c0d15053f73e"
@@ -1119,6 +1127,10 @@ path-is-absolute@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
 
+path-parse@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.5.tgz#3c1adf871ea9cd6c9431b6ea2bd74a0ff055c4c1"
+
 pbkdf2-compat@2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/pbkdf2-compat/-/pbkdf2-compat-2.0.1.tgz#b6e0c8fa99494d94e0511575802a59a5c142f288"
@@ -1240,6 +1252,12 @@ readdirp@^2.0.0:
     readable-stream "^2.0.2"
     set-immediate-shim "^1.0.1"
 
+rechoir@^0.6.2:
+  version "0.6.2"
+  resolved "https://registry.yarnpkg.com/rechoir/-/rechoir-0.6.2.tgz#85204b54dba82d5742e28c96756ef43af50e3384"
+  dependencies:
+    resolve "^1.1.6"
+
 regex-cache@^0.4.2:
   version "0.4.3"
   resolved "https://registry.yarnpkg.com/regex-cache/-/regex-cache-0.4.3.tgz#9b1a6c35d4d0dfcef5711ae651e8e9d3d7114145"
@@ -1279,6 +1297,12 @@ request@^2.79.0:
     tough-cookie "~2.3.0"
     tunnel-agent "~0.4.1"
     uuid "^3.0.0"
+
+resolve@^1.1.6:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.3.1.tgz#5d0a1632609b6b00a22284293db1d5d973676314"
+  dependencies:
+    path-parse "^1.0.5"
 
 right-align@^0.1.1:
   version "0.1.3"
@@ -1323,6 +1347,14 @@ sha.js@2.2.6:
 shelljs@0.3.x:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.3.0.tgz#3596e6307a781544f591f37da618360f31db57b1"
+
+shelljs@0.7.6:
+  version "0.7.6"
+  resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.7.6.tgz#379cccfb56b91c8601e4793356eb5382924de9ad"
+  dependencies:
+    glob "^7.0.0"
+    interpret "^1.0.0"
+    rechoir "^0.6.2"
 
 should-equal@^1.0.0:
   version "1.0.1"


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe: 


**What is the current behavior?** (You can also link to an open issue here)
jshint-loader uses the first .jshintrc file it finds and ignores the `extends` property.


**What is the new behavior?**
Brings jshint-loader to parity with jshint cli with respect to its ability to find and coalesce nested .jshintrc files.


**Does this PR introduce a breaking change?**
- [ ] Yes
- [ ] No 
I don't know whether this is a breaking change. Seems ok to me.

Replaces #36, rebased to master.