### PR TITLE
this.options was deprecated in webpack-4 in favor of this.query

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -10,11 +10,11 @@ const loadRcConfig = require('./loadRcConfig');
 
 function jsHint(input, options) {
   // copy options to own object
-  // if (this.options.jshint) {
-  //   for (const name in this.options.jshint) {
-  //     options[name] = this.options.jshint[name];
-  //   }
-  // }
+  if (this.query.jshint) {
+    for (const name in this.query.jshint) {
+      options[name] = this.query.jshint[name];
+    }
+  }
 
   // copy query into options
   // const query = loaderUtils.getOptions(this) || {};

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@webpack-contrib/schema-utils": "^1.0.0-beta.0",
     "loader-utils": "^1.1.0",
     "lodash": "4.17.5",
-    "rcloader": "=0.1.2",
+    "rcloader": "^0.2.2",
     "shelljs": "0.7.6",
     "strip-json-comments": "0.1.x"
   },

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "dependencies": {
     "@webpack-contrib/schema-utils": "^1.0.0-beta.0",
     "loader-utils": "^1.1.0",
-    "lodash": "4.17.4",
+    "lodash": "4.17.5",
     "rcloader": "=0.1.2",
     "shelljs": "0.7.6",
     "strip-json-comments": "0.1.x"


### PR DESCRIPTION
This modifies all the references to `this.options` in /index.js to `this.query` as the prior was deprecated in favor of the former.

This closes issue #50.