### PR TITLE
fix(security): update dependencies

### DIFF
--- a/lib/loadRcConfig.js
+++ b/lib/loadRcConfig.js
@@ -4,12 +4,12 @@ const RcLoader = require('rcloader');
 const stripJsonComments = require('strip-json-comments');
 
 const shjs = require('shelljs');
-const _ = require('lodash');
+const merge = require('lodash.merge');
 
 // setup RcLoader
 const rcLoader = new RcLoader('.jshintrc', null, {
   loader(path) {
-    return path;
+    return { path };
   },
 });
 
@@ -19,25 +19,25 @@ function loadRcConfig(callback) {
 
   if (sync) {
     const fp = rcLoader.for(this.resourcePath);
-    if (typeof fp !== 'string') {
+    if (typeof fp !== 'object' || typeof fp.path !== 'string') {
       // no .jshintrc found
       return {};
     }
-    this.addDependency(fp);
-    const options = loadConfig(fp);
+    this.addDependency(fp.path);
+    const options = loadConfig(fp.path);
     delete options.dirname;
     return options;
   }
 
   // eslint-disable-next-line consistent-return
   rcLoader.for(this.resourcePath, (err, fp) => {
-    if (typeof fp !== 'string') {
+    if (typeof fp !== 'object' || typeof fp.path !== 'string') {
       // no .jshintrc found
       return callback(null, {});
     }
 
-    this.addDependency(fp);
-    const options = loadConfig(fp);
+    this.addDependency(fp.path);
+    const options = loadConfig(fp.path);
     delete options.dirname;
     callback(err, options);
   });
@@ -61,8 +61,8 @@ function loadConfig(fp) {
         path.resolve(config.dirname, config.extends)
       );
       // eslint-disable-next-line consistent-return
-      config = _.merge({}, baseConfig, config, (a, b) => {
-        if (_.isArray(a)) {
+      config = merge({}, baseConfig, config, (a, b) => {
+        if (Array.isArray(a)) {
           return a.concat(b);
         }
       });

--- a/package-lock.json
+++ b/package-lock.json
@@ -7727,11 +7727,6 @@
         "path-exists": "3.0.0"
       }
     },
-    "lodash": {
-      "version": "4.17.4",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-      "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
-    },
     "lodash._baseassign": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
@@ -7772,6 +7767,11 @@
       "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0=",
       "dev": true
     },
+    "lodash.assign": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
+      "integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc="
+    },
     "lodash.camelcase": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
@@ -7806,6 +7806,11 @@
       "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=",
       "dev": true
     },
+    "lodash.isobject": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-3.0.2.tgz",
+      "integrity": "sha1-PI+41bW/S/kK4G4U8qUwpO2TXh0="
+    },
     "lodash.kebabcase": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.kebabcase/-/lodash.kebabcase-4.1.1.tgz",
@@ -7826,8 +7831,7 @@
     "lodash.merge": {
       "version": "4.6.1",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.1.tgz",
-      "integrity": "sha512-AOYza4+Hf5z1/0Hztxpm2/xiPZgi/cjMqdnKTUWTBSKchJlxXXuUSxCCl8rJlf4g6yww/j6mA8nC8Hw/EZWxKQ==",
-      "dev": true
+      "integrity": "sha512-AOYza4+Hf5z1/0Hztxpm2/xiPZgi/cjMqdnKTUWTBSKchJlxXXuUSxCCl8rJlf4g6yww/j6mA8nC8Hw/EZWxKQ=="
     },
     "lodash.mergewith": {
       "version": "4.6.1",
@@ -9759,19 +9763,14 @@
       }
     },
     "rcloader": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/rcloader/-/rcloader-0.1.2.tgz",
-      "integrity": "sha1-oJY6ZDfQnvjLktky0trUl7DRc2w=",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/rcloader/-/rcloader-0.2.2.tgz",
+      "integrity": "sha1-WNIpi0YtC5v9ITPSoex0+9cFxxc=",
       "requires": {
-        "lodash": "2.4.2",
+        "lodash.assign": "4.2.0",
+        "lodash.isobject": "3.0.2",
+        "lodash.merge": "4.6.1",
         "rcfinder": "0.1.9"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
-          "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4="
-        }
       }
     },
     "read-pkg": {
@@ -10648,9 +10647,9 @@
       "dev": true
     },
     "shelljs": {
-      "version": "0.7.6",
-      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.7.6.tgz",
-      "integrity": "sha1-N5zM+1a5HIYB5HkzVutTgpJN6a0=",
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.2.tgz",
+      "integrity": "sha512-pRXeNrCA2Wd9itwhvLp5LZQvPJ0wU6bcjaTMywHHGX5XWhVN2nzSu7WV0q+oUY7mGK3mgSkDDzP3MgjqdyIgbQ==",
       "requires": {
         "glob": "7.1.2",
         "interpret": "1.1.0",
@@ -11462,9 +11461,9 @@
       "dev": true
     },
     "strip-json-comments": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-0.1.3.tgz",
-      "integrity": "sha1-Fkxk43Coo8wAyeAbU55WmCPw7lQ="
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
     },
     "supports-color": {
       "version": "5.3.0",

--- a/package.json
+++ b/package.json
@@ -40,10 +40,10 @@
   "dependencies": {
     "@webpack-contrib/schema-utils": "^1.0.0-beta.0",
     "loader-utils": "^1.1.0",
-    "lodash": "4.17.4",
-    "rcloader": "=0.1.2",
-    "shelljs": "0.7.6",
-    "strip-json-comments": "0.1.x"
+    "lodash.merge": "^4.6.1",
+    "rcloader": "=0.2.2",
+    "shelljs": "0.8.2",
+    "strip-json-comments": "2.0.1"
   },
   "devDependencies": {
     "@commitlint/cli": "^6.1.3",


### PR DESCRIPTION
This PR contains a:

- [ ] **bugfix**
- [ ] new **feature**
- [x] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

Currently there are several warnings for outdated libraries. These block further changes. See https://david-dm.org/webpack-contrib/jshint-loader

### Breaking Changes

No breaking changes.

### Additional Info

Unfortunately the handling of paths had to be changed, as the updated version of `rcloader` handles merging differently and would return objects containing the characters of the path otherwise (`{ '0': 't', '1': 'e', '2': 's', '3': 't', '4': '/', '5': 'f', '6': 'i', '7': 'x', '8': 't', '9': 'u', '10': 'r', '11': 'e', '12': 's', '13': '/', ... }`).